### PR TITLE
feat: primary vs secondary product status color

### DIFF
--- a/source/home.html
+++ b/source/home.html
@@ -31,6 +31,7 @@
                 image-square
               {% endif %}
             {% endcapture %}
+            {% capture status_class %}{% if product.status == 'active' and product.on_sale %}status-primary{% else %}status-secondary{% endif %}{% endcapture %}
             <div class="product-list-thumb {{ product.css_class }}">
               <a class="product-list-link" href="{{ product.url }}" title="View {{ product.name | escape }}">
                 <div class="product-list-image-container product-list-image-container-{{ theme.grid_image_style }}">
@@ -58,7 +59,7 @@
                       {{ product.default_price | money: theme.money_format }}
                     {% endunless %}
                     {% if product_status != blank %}
-                      <div class="product-list-thumb-status">{{ product_status }}</div>
+                      <div class="product-list-thumb-status {{ status_class }}">{{ product_status }}</div>
                     {% endif %}
                   </div>
                 </div>

--- a/source/product.html
+++ b/source/product.html
@@ -11,14 +11,16 @@
   {% if product.status == 'sold-out' and theme.show_sold_out_product_prices == false %}
     {% assign hide_price = true %}
   {% endif %}
+  {% capture status_class %}{% if product.status == 'active' and product.on_sale %}status-primary{% else %}status-secondary{% endif %}{% endcapture %}
   {% case product.status %}
   {% when 'sold-out' %}
-    <div class="product-subheader">{% unless hide_price %}{{ product_pricing }} {% endunless %}<em>Sold Out</em></div>
+    <div class="product-subheader">{% unless hide_price %}{{ product_pricing }} {% endunless %} <span class="product-status {{ status_class }}">Sold Out</span></div>
   {% when 'coming-soon' %}
-    <div class="product-subheader">{{ product_pricing }} <em>Coming Soon</em></div>
+    <div class="product-subheader">{{ product_pricing }} <span class="product-status {{ status_class }}">Coming Soon</span></div>
   {% when 'active' %}
-    <div class="product-subheader">{{ product_pricing }}{% if product.on_sale %} <em>On Sale{% endif %}</em></div>
+    <div class="product-subheader">{{ product_pricing }}{% if product.on_sale %} <span class="product-status {{ status_class }}">On Sale{% endif %}</div></div>
   {% endcase %}
+  {% capture status_class %}{% if product.status == 'active' and product.on_sale %}status-primary{% else %}status-secondary{% endif %}{% endcapture %}
 
   <div class="product-images desktop-{{ theme.desktop_product_page_images }} mobile-{{ theme.mobile_product_page_images }}" data-total-images="{{ product.images.size }}">
     {% if product.images.size > 1 %}

--- a/source/products.html
+++ b/source/products.html
@@ -44,6 +44,7 @@
                 image-square
               {% endif %}
             {% endcapture %}
+            {% capture status_class %}{% if product.status == 'active' and product.on_sale %}status-primary{% else %}status-secondary{% endif %}{% endcapture %}
             <div class="product-list-thumb {{ product.css_class }}">
               <a class="product-list-link" href="{{ product.url }}" title="View {{ product.name | escape }}">
                 <div class="product-list-image-container product-list-image-container-{{ theme.grid_image_style }}">
@@ -71,7 +72,7 @@
                       {{ product.default_price | money: theme.money_format }}
                     {% endunless %}
                     {% if product_status != blank %}
-                      <div class="product-list-thumb-status">{{ product_status }}</div>
+                      <div class="product-list-thumb-status {{ status_class }}">{{ product_status }}</div>
                     {% endif %}
                   </div>
                 </div>

--- a/source/settings.json
+++ b/source/settings.json
@@ -43,6 +43,8 @@
               "button_text_color": "#FFFFFF",
               "button_background_color": "#000000",
               "button_background_hover_color": "#333333",
+              "product_status_text_color_primary": "#850000",
+              "product_status_text_color_secondary": "#606060",
               "announcement_text_color": "#FFFFFF",
               "announcement_background_color": "#000000"
             }
@@ -64,6 +66,8 @@
               "button_text_color": "#141415",
               "button_background_color": "#F8F8F8",
               "button_background_hover_color": "#B7B6B6",
+              "product_status_text_color_primary": "#ff380b",
+              "product_status_text_color_secondary": "#d7d5dd",
               "announcement_text_color": "#141415",
               "announcement_background_color": "#F8F8F8"
             }
@@ -85,6 +89,8 @@
               "button_text_color": "#F8F8FA",
               "button_background_color": "#2A2A2C",
               "button_background_hover_color": "#203BE1",
+              "product_status_text_color_primary": "#C0392B",
+              "product_status_text_color_secondary": "#606060",
               "announcement_text_color": "#2A2A2C",
               "announcement_background_color": "#E3E4EA"
             }
@@ -109,8 +115,10 @@
               "link_color": "#0000FF",
               "link_hover_color": "#000098",
               "button_text_color": "#0000FF",
-              "button_background_color": "#FFE500",
-              "button_background_hover_color": "#EBD300",
+              "button_background_color": "#F6CD03",
+              "button_background_hover_color": "#F4C200",
+              "product_status_text_color_primary": "#F6CD03",
+              "product_status_text_color_secondary": "#606060",
               "announcement_text_color": "#FFFFFF",
               "announcement_background_color": "#0000FF"
             }
@@ -132,6 +140,8 @@
               "button_text_color": "#243588",
               "button_background_color": "#FFFA8D",
               "button_background_hover_color": "#FFF520",
+              "product_status_text_color_primary": "#D46C91",
+              "product_status_text_color_secondary": "#606060",
               "announcement_text_color": "#243588",
               "announcement_background_color": "#FFFA8D"
             }
@@ -153,6 +163,8 @@
               "button_text_color": "#FFFFFF",
               "button_background_color": "#F90081",
               "button_background_hover_color": "#D1006C",
+              "product_status_text_color_primary": "#007B75",
+              "product_status_text_color_secondary": "#606060",
               "announcement_text_color": "#0B0423",
               "announcement_background_color": "#F6FF20"
             }
@@ -223,6 +235,16 @@
       "variable": "button_background_hover_color",
       "label": "Button background hover",
       "default": "#333333"
+    },
+    {
+      "variable": "product_status_text_color_primary",
+      "label": "Product status text (Primary)",
+      "default": "#AF0000"
+    },
+    {
+      "variable": "product_status_text_color_secondary",
+      "label": "Product status text (Secondary)",
+      "default": "#606060"
     },
     {
       "variable": "announcement_text_color",

--- a/source/stylesheets/layout.css.sass
+++ b/source/stylesheets/layout.css.sass
@@ -25,6 +25,9 @@
   --button-background-color: #{'{{ theme.button_background_color }}'}
   --button-background-hover-color: #{'{{ theme.button_background_hover_color }}'}
 
+  --product-status-text-color-primary: #{"{{ theme.product_status_text_color_primary }}"}
+  --product-status-text-color-secondary: #{"{{ theme.product_status_text_color_secondary }}"}
+
   --announcement-text-color: #{"{{ theme.announcement_text_color }}"}
   --announcement-background-color: #{"{{ theme.announcement_background_color }}"}
 

--- a/source/stylesheets/product.css.sass
+++ b/source/stylesheets/product.css.sass
@@ -27,9 +27,14 @@
     @media only screen and (max-width:$breakpoint-small)
       margin: 16px auto 16px auto
 
-    em
+    .product-status
       font-style: normal
-      color: var(--link-color)
+
+      &.status-primary
+        color: var(--product-status-text-color-primary)
+
+      &.status-secondary
+        color: var(--product-status-text-color-secondary)
 
 .product-details
   +font-size(16)

--- a/source/stylesheets/products.css.sass
+++ b/source/stylesheets/products.css.sass
@@ -135,10 +135,15 @@
   margin-top: 6px
 
 .product-list-thumb-status
-  color: var(--link-color)
   display: inline-block
   font-style: italic
   font-weight: normal
+
+  &.status-primary
+    color: var(--product-status-text-color-primary)
+
+  &.status-secondary
+    color: var(--product-status-text-color-secondary)
 
 .pagination
   +flexbox


### PR DESCRIPTION
Add primary vs secondary product status colors so "on sale" can be differentiated than sold out and coming soon.

![image](https://github.com/user-attachments/assets/59269fc5-79b6-441d-8a73-4a4c0520f488)

![image](https://github.com/user-attachments/assets/77f2ad76-b9c3-4057-957d-2f5226669cb5)
