### PR TITLE
Remove share button on product page

### DIFF
--- a/source/layout.html
+++ b/source/layout.html
@@ -254,7 +254,6 @@
   <script src="{{ 'api' | theme_js_url }}"></script>
   <script src="{{ theme | theme_js_url }}"></script>
   {% if page.full_url contains '/product/' %}
-    <script async defer src="//assets.pinterest.com/js/pinit.js"></script>
     <script>
       Product.find('{{ product.permalink }}', processProduct)
     </script>

--- a/source/product.html
+++ b/source/product.html
@@ -198,31 +198,5 @@
   	    </ul>
       {% endif %}
     {% endif %}
-
-    {% if theme.share_buttons %}
-      <div class="product-section-subheader">Share</div>
-      <ul class="social-links product-share-buttons">
-        <li class="share-twitter">
-          {% capture tweet_string %}{{ product.name }} - {{ store.name }} {{ page.full_url }}{% endcapture %}
-          {% assign tweet_string = tweet_string | url_encode %}
-
-          <a target="_blank" title="Share on Twitter" href="https://twitter.com/intent/tweet?text={{ tweet_string }}" onclick="javascript:window.open(this.href, '', 'menubar=no,toolbar=no,resizable=no,scrollbars=no,height=400,width=600');return false;">
-            <svg class="twitter-icon" height="36" width="36" aria-hidden="true" focusable="false" role="img" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512"><path fill="currentColor" d="M459.37 151.716c.325 4.548.325 9.097.325 13.645 0 138.72-105.583 298.558-298.558 298.558-59.452 0-114.68-17.219-161.137-47.106 8.447.974 16.568 1.299 25.34 1.299 49.055 0 94.213-16.568 130.274-44.832-46.132-.975-84.792-31.188-98.112-72.772 6.498.974 12.995 1.624 19.818 1.624 9.421 0 18.843-1.3 27.614-3.573-48.081-9.747-84.143-51.98-84.143-102.985v-1.299c13.969 7.797 30.214 12.67 47.431 13.319-28.264-18.843-46.781-51.005-46.781-87.391 0-19.492 5.197-37.36 14.294-52.954 51.655 63.675 129.3 105.258 216.365 109.807-1.624-7.797-2.599-15.918-2.599-24.04 0-57.828 46.782-104.934 104.934-104.934 30.213 0 57.502 12.67 76.67 33.137 23.715-4.548 46.456-13.32 66.599-25.34-7.798 24.366-24.366 44.833-46.132 57.827 21.117-2.273 41.584-8.122 60.426-16.243-14.292 20.791-32.161 39.308-52.628 54.253z"></path></svg>
-          </a>
-        </li>
-        <li class="share-facebook">
-          <a target="_blank" title="Share on Facebook" href="https://www.facebook.com/sharer/sharer.php?u={{ page.full_url }}">
-            <svg class="facebook-icon" height="36" width="36" aria-hidden="true" focusable="false" role="img" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512"><path fill="currentColor" d="M504 256C504 119 393 8 256 8S8 119 8 256c0 123.78 90.69 226.38 209.25 245V327.69h-63V256h63v-54.64c0-62.15 37-96.48 93.67-96.48 27.14 0 55.52 4.84 55.52 4.84v61h-31.28c-30.8 0-40.41 19.12-40.41 38.73V256h68.78l-11 71.69h-57.78V501C413.31 482.38 504 379.78 504 256z"></path></svg>
-          </a>
-        </li>
-        <li class="share-pinterest">
-          <a title="Pin" data-pin-custom="true" data-pin-do="buttonPin" href="https://www.pinterest.com/pin/create/button/?url={{ page.full_url }}&media={{ product.images.first.url }}&description={{ product.description | escape | truncate: 200 }}">
-            <svg class="pinterest-icon" height="36" width="36" aria-hidden="true" focusable="false" role="img" role="img" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 496 512"><path fill="currentColor" d="M496 256c0 137-111 248-248 248-25.6 0-50.2-3.9-73.4-11.1 10.1-16.5 25.2-43.5 30.8-65 3-11.6 15.4-59 15.4-59 8.1 15.4 31.7 28.5 56.8 28.5 74.8 0 128.7-68.8 128.7-154.3 0-81.9-66.9-143.2-152.9-143.2-107 0-163.9 71.8-163.9 150.1 0 36.4 19.4 81.7 50.3 96.1 4.7 2.2 7.2 1.2 8.3-3.3.8-3.4 5-20.3 6.9-28.1.6-2.5.3-4.7-1.7-7.1-10.1-12.5-18.3-35.3-18.3-56.6 0-54.7 41.4-107.6 112-107.6 60.9 0 103.6 41.5 103.6 100.9 0 67.1-33.9 113.6-78 113.6-24.3 0-42.6-20.1-36.7-44.8 7-29.5 20.5-61.3 20.5-82.6 0-19-10.2-34.9-31.4-34.9-24.9 0-44.9 25.7-44.9 60.2 0 22 7.4 36.8 7.4 36.8s-24.5 103.8-29 123.2c-5 21.4-3 51.6-.9 71.2C65.4 450.9 0 361.1 0 256 0 119 111 8 248 8s248 111 248 248z"></path>
-            </svg>
-          </a>
-        </li>
-      </ul>
-    {% endif %}
-
   </section>
 </div>

--- a/source/stylesheets/product.css.sass
+++ b/source/stylesheets/product.css.sass
@@ -107,33 +107,6 @@
   .sold_out_text
     margin-left: auto
 
-ul.product-share-buttons
-  display: flex
-  align-items: center
-  justify-content: center
-  gap: 24px
-  margin: 0
-
-  li
-    a
-      display: block
-      height: 24px
-      width: 24px
-
-  .share-pinterest
-
-    a
-      cursor: pointer
-      position: relative
-
-      &:after
-        content: ""
-        position: absolute
-        top: 0
-        right: 0
-        bottom: 0
-        left: 0
-
 .product-artists
   font-family: var(--header-font)
   letter-spacing: .1em


### PR DESCRIPTION
Engagement on these types of Share buttons continues to decrease year over year, so the button is being removed. Instead, visitors can copy/paste URLs, use browser plugins, or use the native share tools on mobile browsers.