### PR TITLE
fix: remove product share setting to match removal of feature

### DIFF
--- a/source/settings.json
+++ b/source/settings.json
@@ -1,6 +1,6 @@
 {
   "name": "Neat",
-  "version": "2.4.0",
+  "version": "2.4.1",
   "images": [
     {
       "variable": "logo",
@@ -489,13 +489,6 @@
       "default": true,
       "description": "Show the price of sold out products on product grids and product pages",
       "requires": "inventory"
-    },
-    {
-      "variable": "share_buttons",
-      "label": "Show product share buttons",
-      "type": "boolean",
-      "default": false,
-      "description": "Adds Facebook, Twitter, and Pinterest buttons to Product pages"
     },
     {
       "variable": "money_format",


### PR DESCRIPTION
Previous PR removed product share buttons on product pages, but forgot to drop the setting.