### PR TITLE
Neat 2.17.1

### DIFF
--- a/source/settings.json
+++ b/source/settings.json
@@ -1,6 +1,6 @@
 {
   "name": "Neat",
-  "version": "2.17.0",
+  "version": "2.17.1",
   "images": [
     {
       "variable": "logo",
@@ -870,6 +870,7 @@
       "type": "select",
       "options": "0..48",
       "default": 6,
+      "upgrade_default": 0,
       "description": "The number of categories featured on the Home page"
     },
     {


### PR DESCRIPTION
chore: featured categories default to 0 for upgrades