### PR TITLE
Neat v2.19.0

### DIFF
--- a/source/cart.html
+++ b/source/cart.html
@@ -46,9 +46,31 @@
               </a>
               <div class="option-name">
                 {% unless item.product.has_default_option %}
-                  {{ item.option.name }} - <span class="cart-item-unit-price">{{ item.unit_price | money: theme.money_format }}</span>
+                  {{ item.option.name }} - <span class="cart-item-unit-price">
+                    {% assign show_strikethrough = false %}
+                    {% if theme.show_strikethrough_pricing and item.original_unit_price > item.unit_price %}
+                      {% assign show_strikethrough = true %}
+                    {% endif %}
+                    {% if show_strikethrough %}
+                      <s class="price-compare">{{ item.original_unit_price | money: theme.money_format }}</s>
+                      <span class="price-sale">{{ item.unit_price | money: theme.money_format }}</span>
+                    {% else %}
+                      {{ item.unit_price | money: theme.money_format }}
+                    {% endif %}
+                  </span>
                 {% else %}
-                  <div class="cart-item-unit-price">{{ item.unit_price | money: theme.money_format }}</div>
+                  <div class="cart-item-unit-price">
+                    {% assign show_strikethrough = false %}
+                    {% if theme.show_strikethrough_pricing and item.original_unit_price > item.unit_price %}
+                      {% assign show_strikethrough = true %}
+                    {% endif %}
+                    {% if show_strikethrough %}
+                      <s class="price-compare">{{ item.original_unit_price | money: theme.money_format }}</s>
+                      <span class="price-sale">{{ item.unit_price | money: theme.money_format }}</span>
+                    {% else %}
+                      {{ item.unit_price | money: theme.money_format }}
+                    {% endif %}
+                  </div>
                 {% endunless %}
               </div>
             </div>

--- a/source/home.html
+++ b/source/home.html
@@ -128,7 +128,7 @@
                   {% unless hide_price %}
                     {% if product.options.size > 1 and theme.show_product_variant_count_in_grid %}
                       <div class="product-list-thumb-options-description">
-                        {{ product.options.size }} {{ t['products.variants'] }}
+                        {{ product.options.size }} {{ t['products.variants'] | downcase }}
                       </div>
                     {% endif %}
                   {% endunless %}

--- a/source/home.html
+++ b/source/home.html
@@ -108,7 +108,32 @@
                     {% endif %}
 
                     {% unless hide_price %}
-                      {{ product | product_price: theme.money_format, theme.product_variable_pricing_display_format }}
+                      {% assign show_strikethrough = false %}
+                      {% assign strikethrough_regular = nil %}
+                      {% assign strikethrough_sale = nil %}
+
+                      {% if theme.show_strikethrough_pricing %}
+                        {% if product.variable_pricing == false and product.original_price > product.default_price %}
+                          {% assign show_strikethrough = true %}
+                          {% assign strikethrough_regular = product.original_price %}
+                          {% assign strikethrough_sale = product.default_price %}
+                        {% elsif product.variable_pricing and theme.product_variable_pricing_display_format == "min_only" and product.min_original_price > product.min_price %}
+                          {% assign show_strikethrough = true %}
+                          {% assign strikethrough_regular = product.min_original_price %}
+                          {% assign strikethrough_sale = product.min_price %}
+                        {% elsif product.variable_pricing and theme.product_variable_pricing_display_format == "max_only" and product.max_original_price > product.max_price %}
+                          {% assign show_strikethrough = true %}
+                          {% assign strikethrough_regular = product.max_original_price %}
+                          {% assign strikethrough_sale = product.max_price %}
+                        {% endif %}
+                      {% endif %}
+
+                      {% if show_strikethrough %}
+                        <s class="price-compare">{{ strikethrough_regular | money: theme.money_format }}</s>
+                        <span class="price-sale">{{ strikethrough_sale | money: theme.money_format }}</span>
+                      {% else %}
+                        {{ product | product_price: theme.money_format, theme.product_variable_pricing_display_format }}
+                      {% endif %}
 
                       {% if product.price_suffix != blank %}
                         {% assign variable_price_shown = true %}

--- a/source/javascripts/cart.js
+++ b/source/javascripts/cart.js
@@ -166,10 +166,13 @@ processUpdate = (input, item_id, new_val, cart) => {
   if (new_val > 0) {
     for (itemIndex = 0; itemIndex < cart.items.length; itemIndex++) {
       if (cart.items[itemIndex].id == item_id) {
-        item_price = cart.items[itemIndex].price;
-        formatted_item_price = formatMoney(item_price, true, true);
-        let priceElement = document.querySelector('.cart-item-price__update[data-item-id="'+item_id+'"]');
-        htmlHighlight(priceElement,formatted_item_price);
+        var item = cart.items[itemIndex];
+        var item_price = item.price;
+        var priceElement = document.querySelector('.cart-item-price__update[data-item-id="'+item_id+'"]');
+
+        // Line total only shows sale price (no strikethrough - strikethrough is on unit price only)
+        var formattedPrice = formatMoney(item_price, true, true);
+        htmlHighlight(priceElement, formattedPrice);
       }
     }
   }

--- a/source/javascripts/product-option-groups.js
+++ b/source/javascripts/product-option-groups.js
@@ -305,7 +305,7 @@ function processAvailableDropdownOptions(product, changed_dropdown) {
     if (product_option) {
       if (!product_option.sold_out && product_option.id > 0) {
         $('#option').val(product_option.id);
-        enableAddButton(product_option.price);
+        enableAddButton(product_option.price, product_option.original_price);
         if (num_option_groups > 1) {
           $('.reset-selection-button').fadeIn('fast');
         }

--- a/source/javascripts/product.js
+++ b/source/javascripts/product.js
@@ -96,7 +96,18 @@ function updateInventoryMessage(optionId = null) {
 
 function updateProductPrice(updated_price, original_price) {
   var priceContainer = $('.product-price-value');
-  if (!priceContainer.length || !updated_price) return;
+  if (!priceContainer.length) return;
+
+  if (!updated_price) {
+    if (priceContainer.data('original-html') !== undefined) {
+      priceContainer.html(priceContainer.data('original-html'));
+    }
+    return;
+  }
+
+  if (priceContainer.data('original-html') === undefined) {
+    priceContainer.data('original-html', priceContainer.html());
+  }
 
   var updatedNum = parseFloat(updated_price) || 0;
   var originalNum = parseFloat(original_price) || 0;

--- a/source/javascripts/product.js
+++ b/source/javascripts/product.js
@@ -30,7 +30,8 @@ if (themeOptions.productImageZoom === true) {
 }
 $('.product_option_select').on('change',function() {
   var option_price = $(this).find("option:selected").attr("data-price");
-  enableAddButton(option_price);
+  var original_price = $(this).find("option:selected").attr("data-original-price");
+  enableAddButton(option_price, original_price);
 });
 
 function updateInventoryMessage(optionId = null) {
@@ -93,19 +94,35 @@ function updateInventoryMessage(optionId = null) {
   }
 }
 
-function enableAddButton(updated_price) {
+function updateProductPrice(updated_price, original_price) {
+  var priceContainer = $('.product-price-value');
+  if (!priceContainer.length || !updated_price) return;
+
+  var updatedNum = parseFloat(updated_price) || 0;
+  var originalNum = parseFloat(original_price) || 0;
+
+  var showStrikethrough = originalNum > updatedNum && themeOptions.showStrikethroughPricing;
+
+  var priceHtml;
+  if (showStrikethrough) {
+    var regularFormatted = formatMoney(original_price, true, true);
+    var saleFormatted = formatMoney(updated_price, true, true);
+    priceHtml = '<s class="price-compare">' + regularFormatted + '</s> <span class="price-sale">' + saleFormatted + '</span>';
+  } else {
+    priceHtml = formatMoney(updated_price, true, true);
+  }
+
+  priceContainer.html(priceHtml);
+}
+
+function enableAddButton(updated_price, original_price) {
   var addButton = $('.add-to-cart-button');
   var addButtonTitle = addButton.attr('data-add-title');
   addButton.attr("disabled",false);
-  if (updated_price) {
-    priceTitle = ' - ' + formatMoney(updated_price, true, true);
-  }
-  else {
-    priceTitle = '';
-  }
-  addButton.html(addButtonTitle + priceTitle);
-  addButton.attr('aria-label',addButton.text());
+  addButton.html(addButtonTitle);
+  addButton.attr('aria-label', addButtonTitle);
   updateInventoryMessage($('#option').val());
+  updateProductPrice(updated_price, original_price);
   showBnplMessaging(updated_price, { alignment: 'center', displayMode: 'flex', pageType: 'product' });
 }
 

--- a/source/layout.html
+++ b/source/layout.html
@@ -213,7 +213,32 @@
                         {% endif %}
 
                         {% unless hide_price %}
-                          {{ related_product | product_price: theme.money_format, theme.product_variable_pricing_display_format }}
+                          {% assign show_strikethrough = false %}
+                          {% assign strikethrough_regular = nil %}
+                          {% assign strikethrough_sale = nil %}
+
+                          {% if theme.show_strikethrough_pricing %}
+                            {% if related_product.variable_pricing == false and related_product.original_price > related_product.default_price %}
+                              {% assign show_strikethrough = true %}
+                              {% assign strikethrough_regular = related_product.original_price %}
+                              {% assign strikethrough_sale = related_product.default_price %}
+                            {% elsif related_product.variable_pricing and theme.product_variable_pricing_display_format == "min_only" and related_product.min_original_price > related_product.min_price %}
+                              {% assign show_strikethrough = true %}
+                              {% assign strikethrough_regular = related_product.min_original_price %}
+                              {% assign strikethrough_sale = related_product.min_price %}
+                            {% elsif related_product.variable_pricing and theme.product_variable_pricing_display_format == "max_only" and related_product.max_original_price > related_product.max_price %}
+                              {% assign show_strikethrough = true %}
+                              {% assign strikethrough_regular = related_product.max_original_price %}
+                              {% assign strikethrough_sale = related_product.max_price %}
+                            {% endif %}
+                          {% endif %}
+
+                          {% if show_strikethrough %}
+                            <s class="price-compare">{{ strikethrough_regular | money: theme.money_format }}</s>
+                            <span class="price-sale">{{ strikethrough_sale | money: theme.money_format }}</span>
+                          {% else %}
+                            {{ related_product | product_price: theme.money_format, theme.product_variable_pricing_display_format }}
+                          {% endif %}
 
                           {% if related_product.price_suffix != blank %}
                             {% assign variable_price_shown = true %}
@@ -580,6 +605,7 @@
       welcomeButtonLink: "{{ theme.welcome_button_link }}",
       welcomeSlideshowLink: "{{ theme.welcome_slideshow_link }}",
       showBnplMessaging: {{ theme.show_bnpl_messaging }},
+      showStrikethroughPricing: {{ theme.show_strikethrough_pricing }},
     };
     const themeColors = {
       primaryTextColor: '{{ theme.text_color }}',

--- a/source/layout.html
+++ b/source/layout.html
@@ -233,7 +233,7 @@
                       {% unless hide_price %}
                         {% if related_product.options.size > 1 and theme.show_product_variant_count_in_grid %}
                           <div class="product-list-thumb-options-description">
-                            {{ related_product.options.size }} {{ t['products.variants'] }}
+                            {{ related_product.options.size }} {{ t['products.variants'] | downcase }}
                           </div>
                         {% endif %}
                       {% endunless %}

--- a/source/product.html
+++ b/source/product.html
@@ -1,7 +1,17 @@
 <div class="product-container" data-bc-hook="product-container">
   <h1>{{ product.name }}</h1>
   {% capture product_pricing %}
-    {{ product | product_price: theme.money_format }}
+    {% assign show_strikethrough = false %}
+    {% if theme.show_strikethrough_pricing and product.variable_pricing == false and product.original_price > product.default_price %}
+      {% assign show_strikethrough = true %}
+    {% endif %}
+
+    {% if show_strikethrough %}
+      <s class="price-compare">{{ product.original_price | money: theme.money_format }}</s>
+      <span class="price-sale">{{ product.default_price | money: theme.money_format }}</span>
+    {% else %}
+      {{ product | product_price: theme.money_format }}
+    {% endif %}
   {% endcapture %}
   {% assign hide_price = false %}
   {% if product.status == 'sold-out' and theme.show_sold_out_product_prices == false %}
@@ -22,7 +32,7 @@
     </div>
   {% when 'active' %}
     <div class="product-subheader">
-      {{ product_pricing }}
+      <span class="product-price-value">{{ product_pricing }}</span>
 
       {% if product.price_suffix != blank %}
         {% assign variable_price_shown = true %}
@@ -161,7 +171,22 @@
                   <select data-unavailable-text="(Unavailable)" data-sold-text="({{ t['products.sold_out'] }})" data-group-id="{{ option_group.id }}" data-group-name="{{ option_group.name | escape }}" class="product_option_group" name="option_group[{{ option_group.id }}]" aria-label="Select {{ option_group.name | escape }}" required>
                     <option value="" disabled="disabled" selected>{{ option_group.name }}</option>
                     {% for value in option_group.values %}
-                      <option value="{{ value.id }}" data-name="{{ value.name | escape }}">{{ value.name }}</option>
+                      {% assign option_status_label = '' %}
+                      {% if product.option_groups.size == 1 %}
+                        {% for option in product.options %}
+                          {% for ogv in option.option_group_values %}
+                            {% if ogv.id == value.id %}
+                              {% if option.sold_out %}
+                                {% assign option_status_label = t['products.sold_out'] | downcase %}
+                              {% elsif option.original_price > option.price and theme.show_sale_label_in_product_options %}
+                                {% assign option_status_label = t['products.on_sale'] | downcase %}
+                              {% endif %}
+                              {% break %}
+                            {% endif %}
+                          {% endfor %}
+                        {% endfor %}
+                      {% endif %}
+                      <option value="{{ value.id }}" data-name="{{ value.name | escape }}">{{ value.name }}{% if option_status_label != blank %} ({{ option_status_label }}){% endif %}</option>
                     {% endfor %}
                   </select>
                   <svg aria-hidden="true" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" version="1.1" x="0px" y="0px" xml:space="preserve" viewBox="0 0 10 5.96"><path class="down_arrow" d="M9.852 1.537c0.199-0.189 0.199-0.496 0-0.684L9.135 0.17C8.938-0.02 8.617-0.02 8.4 0.17L5.016 3.5 L1.582 0.143c-0.199-0.189-0.52-0.189-0.717 0L0.148 0.826c-0.197 0.188-0.197 0.5 0 0.684l4.508 4.3 c0.199 0.2 0.5 0.2 0.7 0L9.852 1.537z"></path></svg>
@@ -173,7 +198,7 @@
               <select class="product_option_select" id="option" name="cart[add][id]" aria-label="{{ t['products.select_variant'] }}" required>
                 <option value="" disabled="disabled" selected>{{ t['products.select_variant'] }}</option>
                 {% for option in product.options %}
-                  <option value="{{ option.id }}" data-price="{{ option.price }}"{% if option.sold_out %} disabled="disabled" disabled-type="sold-out"{% endif %}>{{ option.name }} {% if option.sold_out %} ({{ t['products.sold_out'] }}){% endif %}</option>
+                  <option value="{{ option.id }}" data-price="{{ option.price }}" data-original-price="{{ option.original_price }}"{% if option.sold_out %} disabled="disabled" disabled-type="sold-out"{% endif %}>{{ option.name }}{% if option.sold_out %} ({{ t['products.sold_out'] | downcase }}){% elsif option.original_price > option.price and theme.show_sale_label_in_product_options %} ({{ t['products.on_sale'] | downcase }}){% endif %}</option>
                 {% endfor %}
               </select>
               <svg aria-hidden="true" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" version="1.1" x="0px" y="0px" xml:space="preserve" viewBox="0 0 10 5.96"><path class="down_arrow" d="M9.852 1.537c0.199-0.189 0.199-0.496 0-0.684L9.135 0.17C8.938-0.02 8.617-0.02 8.4 0.17L5.016 3.5 L1.582 0.143c-0.199-0.189-0.52-0.189-0.717 0L0.148 0.826c-0.197 0.188-0.197 0.5 0 0.684l4.508 4.3 c0.199 0.2 0.5 0.2 0.7 0L9.852 1.537z"></path></svg>

--- a/source/product.html
+++ b/source/product.html
@@ -70,9 +70,19 @@
                 {% endif %}
                   <img
                     alt="Image {{ forloop.index }} of {{ product.name | escape }}"
-                    class="product-image lazyload"
+                    class="product-image{% unless forloop.index == 1 %} lazyload{% endunless %}"
                     {% if forloop.index == 1 %}fetchpriority="high"{% else %}loading="lazy"{% endif %}
                     src="{{ image | product_image_url | constrain: 200 }}"
+                    {% if forloop.index == 1 %}
+                    srcset="
+                      {{ image | product_image_url | constrain: 400 }} 400w,
+                      {{ image | product_image_url | constrain: 700 }} 700w,
+                      {{ image | product_image_url | constrain: 1000 }} 1000w,
+                      {{ image | product_image_url | constrain: 1400 }} 1400w,
+                      {{ image | product_image_url | constrain: 2000 }} 2000w,
+                    "
+                    sizes="(min-width: 768px) 50vw, 100vw"
+                    {% else %}
                     data-srcset="
                       {{ image | product_image_url | constrain: 400 }} 400w,
                       {{ image | product_image_url | constrain: 700 }} 700w,
@@ -80,9 +90,10 @@
                       {{ image | product_image_url | constrain: 1400 }} 1400w,
                       {{ image | product_image_url | constrain: 2000 }} 2000w,
                     "
+                    data-sizes="auto"
+                    {% endif %}
                     width="{{ image.height | times: aspect_ratio }}"
                     height="{{ image.height }}"
-                    data-sizes="auto"
                   >
                 {% if theme.product_image_zoom %}</a>{% else %}</div>{% endif %}
               </div>
@@ -140,17 +151,17 @@
       {% endif %}
         <img
           alt="{{ product.name | escape }}"
-          class="blur-up product-image lazyload"
+          class="blur-up product-image"
           fetchpriority="high"
           src="{{ product.image | product_image_url | constrain: 200 }}"
-          data-srcset="
+          srcset="
             {{ product.image | product_image_url | constrain: 400 }} 400w,
             {{ product.image | product_image_url | constrain: 700 }} 700w,
             {{ product.image | product_image_url | constrain: 1000 }} 1000w,
             {{ product.image | product_image_url | constrain: 1400 }} 1400w,
             {{ product.image | product_image_url | constrain: 2000 }} 2000w,
           "
-          data-sizes="auto"
+          sizes="(min-width: 768px) 50vw, 100vw"
         >
       {% if theme.product_image_zoom %}</a>{% else %}</div>{% endif %}
     {% endif %}

--- a/source/product.html
+++ b/source/product.html
@@ -200,9 +200,7 @@
         </div>
       </div>
     {% endif %}
-    {% if product.description != blank %}
-      <div class="product-description">{{ product.description | paragraphs }}</div>
-    {% endif %}
+    <div class="product-description" data-bc-hook="product-description">{%- if product.description != blank %}{{ product.description | paragraphs }}{% endif -%}</div>
 
     {% if product.artists != blank %}
       <section class="product-artists">

--- a/source/product.html
+++ b/source/product.html
@@ -117,6 +117,7 @@
                 <img
                   alt=""
                   class="lazyload"
+                  loading="lazy"
                   src="{{ image | product_image_url | constrain: 150 }}"
                   data-srcset="
                     {{ image | product_image_url | constrain: 250 }} 250w,

--- a/source/products.html
+++ b/source/products.html
@@ -89,7 +89,32 @@
                     {% endif %}
 
                     {% unless hide_price %}
-                      {{ product | product_price: theme.money_format, theme.product_variable_pricing_display_format }}
+                      {% assign show_strikethrough = false %}
+                      {% assign strikethrough_regular = nil %}
+                      {% assign strikethrough_sale = nil %}
+
+                      {% if theme.show_strikethrough_pricing %}
+                        {% if product.variable_pricing == false and product.original_price > product.default_price %}
+                          {% assign show_strikethrough = true %}
+                          {% assign strikethrough_regular = product.original_price %}
+                          {% assign strikethrough_sale = product.default_price %}
+                        {% elsif product.variable_pricing and theme.product_variable_pricing_display_format == "min_only" and product.min_original_price > product.min_price %}
+                          {% assign show_strikethrough = true %}
+                          {% assign strikethrough_regular = product.min_original_price %}
+                          {% assign strikethrough_sale = product.min_price %}
+                        {% elsif product.variable_pricing and theme.product_variable_pricing_display_format == "max_only" and product.max_original_price > product.max_price %}
+                          {% assign show_strikethrough = true %}
+                          {% assign strikethrough_regular = product.max_original_price %}
+                          {% assign strikethrough_sale = product.max_price %}
+                        {% endif %}
+                      {% endif %}
+
+                      {% if show_strikethrough %}
+                        <s class="price-compare">{{ strikethrough_regular | money: theme.money_format }}</s>
+                        <span class="price-sale">{{ strikethrough_sale | money: theme.money_format }}</span>
+                      {% else %}
+                        {{ product | product_price: theme.money_format, theme.product_variable_pricing_display_format }}
+                      {% endif %}
 
                       {% if product.price_suffix != blank %}
                         {% assign variable_price_shown = true %}

--- a/source/products.html
+++ b/source/products.html
@@ -109,7 +109,7 @@
                   {% unless hide_price %}
                     {% if product.options.size > 1 and theme.show_product_variant_count_in_grid %}
                       <div class="product-list-thumb-options-description">
-                        {{ product.options.size }} {{ t['products.variants'] }}
+                        {{ product.options.size }} {{ t['products.variants'] | downcase }}
                       </div>
                     {% endif %}
                   {% endunless %}

--- a/source/settings.json
+++ b/source/settings.json
@@ -1,6 +1,6 @@
 {
   "name": "Neat",
-  "version": "2.18.5",
+  "version": "2.19.0",
   "images": [
     {
       "variable": "logo_image",

--- a/source/settings.json
+++ b/source/settings.json
@@ -593,7 +593,8 @@
       "options": [
         ["Default (Sentence case)", "initial"],
         ["Uppercase", "uppercase"],
-        ["Lowercase", "lowercase"]
+        ["Lowercase", "lowercase"],
+        ["Titlecase", "capitalize"]
       ],
       "default": "initial",
       "description": "Controls the text case styling in your main navigation"
@@ -606,7 +607,8 @@
       "options": [
         ["Default (Sentence case)", "initial"],
         ["Uppercase", "uppercase"],
-        ["Lowercase", "lowercase"]
+        ["Lowercase", "lowercase"],
+        ["Titlecase", "capitalize"]
       ],
       "default": "initial",
       "description": "Controls the text case styling in the footer, excluding custom footer text"

--- a/source/settings.json
+++ b/source/settings.json
@@ -1115,6 +1115,25 @@
       }
     },
     {
+      "variable": "show_strikethrough_pricing",
+      "label": "Show strikethrough pricing",
+      "section": "product_page",
+      "type": "boolean",
+      "default": true,
+      "description": "Show the original price crossed out next to the sale price",
+      "requires": [
+        "feature:theme_strikethrough_pricing eq visible"
+      ]
+    },
+    {
+      "variable": "show_sale_label_in_product_options",
+      "label": "Show sale label in variant dropdowns",
+      "section": "product_page",
+      "type": "boolean",
+      "default": true,
+      "description": "Adds a sale indicator next to discounted variants in the dropdown"
+    },
+    {
       "variable": "maintenance_message",
       "label": "Maintenance mode message",
       "section": "messaging",

--- a/source/stylesheets/product.css.sass
+++ b/source/stylesheets/product.css.sass
@@ -70,6 +70,9 @@
 .product-description
   font-size: 1rem
   font-size: calc(1rem * var(--product-description-scale, 1))
+
+  &:empty
+    display: none
   a
     text-decoration: underline
     text-underline-offset: 3px

--- a/source/stylesheets/products.css.sass
+++ b/source/stylesheets/products.css.sass
@@ -158,6 +158,12 @@
   @media screen and (max-width: $breakpoint-small)
     font-size: calc(0.8rem * var(--product-grid-scale, 1))
 
+// Strikethrough pricing styles
+.price-compare
+  text-decoration: line-through
+  opacity: 0.6
+  margin-right: 0.3em
+
 .price-suffix
   white-space: nowrap
 


### PR DESCRIPTION
## Summary

### Features
- **Strikethrough pricing** — Display original prices with strikethrough when items are on sale
- **Titlecase nav text transformation** — New option to apply titlecase formatting to navigation text

### Fixes
- **Product description container always in DOM** — The product description container is now always rendered (with a `data-bc-hook`) so it can be targeted by JS, and hidden via CSS `:empty` when there's no description

### Chores
- Lowercase label for options text in product grid
- Version bump to 2.19.0